### PR TITLE
6027 iOS check app state in SDK

### DIFF
--- a/Sdk/Talk/SwrveMessageController.m
+++ b/Sdk/Talk/SwrveMessageController.m
@@ -1086,12 +1086,16 @@ static NSNumber* numberFromJsonWithDefault(NSDictionary* json, NSString* key, in
 - (void) pushNotificationReceived:(NSDictionary*)userInfo
 {
     if (self.pushEnabled) {
-        [self.analyticsSDK pushNotificationReceived:userInfo];
-        if (self.qaUser) {
-           [self.qaUser pushNotification:userInfo];
-        } else {
-            DebugLog(@"Queuing push notification for later", nil);
-            [self.notifications addObject:userInfo];
+        // Do not process the push notification if the app was on the foreground
+        UIApplicationState swrveState = [[UIApplication sharedApplication] applicationState];
+        if (swrveState == UIApplicationStateInactive || swrveState == UIApplicationStateBackground) {
+            [self.analyticsSDK pushNotificationReceived:userInfo];
+            if (self.qaUser) {
+               [self.qaUser pushNotification:userInfo];
+            } else {
+                DebugLog(@"Queuing push notification for later", nil);
+                [self.notifications addObject:userInfo];
+            }
         }
     }
 }


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-6027
Private changes: https://github.com/Swrve/swrve-sdk/pull/742

Move the check for app state into the SDK, previously written in the app code. Prevents push notifications from being processed by the SDK and custom listener if the app is in the foreground.
