### PR TITLE
Log product id as a payload of the IAP event

### DIFF
--- a/Sdk/Track/Swrve.m
+++ b/Sdk/Track/Swrve.m
@@ -864,6 +864,10 @@ static bool didSwizzle = false;
             [json setValue:[NSNumber numberWithDouble:localCost] forKey:@"cost"];
             [json setValue:[rewards rewards] forKey:@"rewards"];
             [json setValue:encodedReceipt forKey:@"receipt"];
+            // Payload data
+            NSMutableDictionary* eventPayload = [[NSMutableDictionary alloc] init];
+            [eventPayload setValue:product_id forKey:@"product_id"];
+            [json setValue:eventPayload forKey:@"payload"];
             if ( receipt.transactionId ) {
                 // Send transactionId only for iOS7+. This is how the server knows it is an iOS7 receipt!
                 [json setValue:receipt.transactionId forKey:@"transaction_id"];


### PR DESCRIPTION
Log the product ID from the SKPayment so it can be seen in the QA user log page.

https://swrvedev.jira.com/browse/SWRVE-6848
Private changes: https://github.com/Swrve/swrve-sdk/pull/750
