### PR TITLE
Allowing the user to disable Swrve from choosing if the status bar is…

### DIFF
--- a/Sdk/Talk/SwrveMessageController.m
+++ b/Sdk/Talk/SwrveMessageController.m
@@ -70,6 +70,7 @@ const static int DEFAULT_MIN_DELAY           = 55;
 @property (nonatomic, retain) UIViewController*     conversationViewController;
 @property (nonatomic)         SwrveActionType       inAppMessageActionType;
 @property (nonatomic, retain) NSString*             inAppMessageAction;
+@property (nonatomic)         bool                  shouldAutoInferStatusBarAppearance;
 
 // Current Device Properties
 @property (nonatomic) int device_width;
@@ -130,6 +131,7 @@ const static int DEFAULT_MIN_DELAY           = 55;
 @synthesize hideMessageTransition;
 @synthesize swrveConversationsNavigationController;
 @synthesize swrveConversationItemViewController;
+@synthesize shouldAutoInferStatusBarAppearance;
 
 + (void)initialize {
     ALL_SUPPORTED_DYNAMIC_DEVICE_FILTERS = [NSArray arrayWithObjects:
@@ -151,6 +153,7 @@ const static int DEFAULT_MIN_DELAY           = 55;
     self.device_height = (int)screen_bounds.size.width;
     self.device_width  = (int)screen_bounds.size.height;
     self.orientation   = sdk.config.orientation;
+    self.shouldAutoInferStatusBarAppearance = sdk.config.shouldAutoInferStatusBarAppearance;
     
     self.language           = sdk.config.language;
     self.user               = sdk.userID;
@@ -1043,6 +1046,7 @@ static NSNumber* numberFromJsonWithDefault(NSDictionary* json, NSString* key, in
     if ( message && self.inAppMessageWindow == nil && self.conversationViewController == nil ) {
         SwrveMessageViewController* messageViewController = [[SwrveMessageViewController alloc] init];
         messageViewController.view.backgroundColor = self.backgroundColor;
+        messageViewController.shouldAutoInferStatusBarAppearance = self.shouldAutoInferStatusBarAppearance;
         messageViewController.message = message;
         messageViewController.block = ^(SwrveActionType type, NSString* action, NSInteger appId) {
 #pragma unused(appId)

--- a/Sdk/Talk/SwrveMessageViewController.h
+++ b/Sdk/Talk/SwrveMessageViewController.h
@@ -7,6 +7,7 @@
 
 @property (nonatomic, retain) SwrveMessage*      message;   /*!< Message to render. */
 @property (nonatomic, copy)   SwrveMessageResult block;     /*!< Custom code to execute when a button is tapped or a message is dismissed by a user. */
+@property (nonatomic)         BOOL               shouldAutoInferStatusBarAppearance; /*!< Allows the view controler to decide if the status bar is visible. */
 
 /*! Called by the view when a button is pressed */
 -(IBAction)onButtonPressed:(id)sender;

--- a/Sdk/Talk/SwrveMessageViewController.m
+++ b/Sdk/Talk/SwrveMessageViewController.m
@@ -22,6 +22,7 @@
 @synthesize wasShownToUserNotified;
 @synthesize viewportWidth;
 @synthesize viewportHeight;
+@synthesize shouldAutoInferStatusBarAppearance;
 
 - (void)viewWillAppear:(BOOL)animated
 {
@@ -99,7 +100,11 @@
 #ifdef __IPHONE_8_0
 -(BOOL)prefersStatusBarHidden
 {
-    return YES;
+    if (shouldAutoInferStatusBarAppearance) {
+        return YES;
+    } else {
+        return [super prefersStatusBarHidden];
+    }
 }
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/Sdk/Track/Swrve.h
+++ b/Sdk/Track/Swrve.h
@@ -98,6 +98,13 @@ typedef void (^SwrveResourcesUpdatedListener) ();
 /*! The supported orientations of the app. */
 @property (nonatomic) SwrveInterfaceOrientation orientation;
 
+/*! By default Swrve will choose the status bar appearance
+ * when presenting any view controllers.  
+ * You can disable this functionality by setting
+ * shouldAutoInferStatusBarAppearance to false.
+ */
+@property (nonatomic) BOOL shouldAutoInferStatusBarAppearance;
+
 /*! By default Swrve will read the application version from the current
  * application bundle. This is used to allow you to test and target users with a
  * particular application version.
@@ -260,6 +267,7 @@ typedef void (^SwrveResourcesUpdatedListener) ();
 
 - (id)initWithSwrveConfig:(SwrveConfig*)config;
 @property (nonatomic, readonly) SwrveInterfaceOrientation orientation;
+@property (nonatomic, readonly) BOOL shouldAutoInferStatusBarAppearance;
 @property (nonatomic, readonly) int httpTimeoutSeconds;
 @property (nonatomic, readonly) NSString * eventsServer;
 @property (nonatomic, readonly) BOOL useHttpsForEventServer;

--- a/Sdk/Track/Swrve.m
+++ b/Sdk/Track/Swrve.m
@@ -292,6 +292,7 @@ enum
 @implementation SwrveConfig
 
 @synthesize orientation;
+@synthesize shouldAutoInferStatusBarAppearance;
 @synthesize httpTimeoutSeconds;
 @synthesize eventsServer;
 @synthesize useHttpsForEventServer;
@@ -329,6 +330,7 @@ enum
         autoDownloadCampaignsAndResources = YES;
         maxConcurrentDownloads = 2;
         orientation = SWRVE_ORIENTATION_BOTH;
+        shouldAutoInferStatusBarAppearance = YES;
         appVersion = [Swrve getAppVersion];
         language = [[NSLocale preferredLanguages] objectAtIndex:0];
         newSessionInterval = 30;
@@ -366,6 +368,7 @@ enum
 @implementation ImmutableSwrveConfig
 
 @synthesize orientation;
+@synthesize shouldAutoInferStatusBarAppearance;
 @synthesize httpTimeoutSeconds;
 @synthesize eventsServer;
 @synthesize useHttpsForEventServer;
@@ -400,6 +403,7 @@ enum
 {
     if (self = [super init]) {
         orientation = config.orientation;
+        shouldAutoInferStatusBarAppearance = config.shouldAutoInferStatusBarAppearance;
         httpTimeoutSeconds = config.httpTimeoutSeconds;
         eventsServer = config.eventsServer;
         useHttpsForEventServer = config.useHttpsForEventServer;


### PR DESCRIPTION
When showing app messages, the swrve sdks forces the status bar to hide under default behavior.  I added a boolean to the config to allow the user to disable this functionality.
