### PR TITLE
9978 Remove 'unbalanced calls' warning

### DIFF
--- a/Sdk/Conversation/SwrveConversationContainerViewController.h
+++ b/Sdk/Conversation/SwrveConversationContainerViewController.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface SwrveConversationContainerViewController : UIViewController
+
+-(id) initWithChildViewController:(UIViewController*)childController;
+
+@end

--- a/Sdk/Conversation/SwrveConversationContainerViewController.m
+++ b/Sdk/Conversation/SwrveConversationContainerViewController.m
@@ -1,0 +1,31 @@
+#import "SwrveConversationContainerViewController.h"
+
+@interface SwrveConversationContainerViewController ()
+
+@property (nonatomic, retain) UIViewController* childController;
+@property (nonatomic) BOOL displayedChildrenViewController;
+
+@end
+
+@implementation SwrveConversationContainerViewController
+
+@synthesize childController;
+@synthesize displayedChildrenViewController;
+
+-(id) initWithChildViewController:(UIViewController*)child {
+    if (self = [super init]) {
+        self.childController = child;
+    }
+    return self;
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    if (!displayedChildrenViewController) {
+        displayedChildrenViewController = YES;
+        [self presentViewController:childController animated:YES completion:nil];
+    }
+}
+
+@end

--- a/Sdk/Talk/SwrveMessageController.m
+++ b/Sdk/Talk/SwrveMessageController.m
@@ -8,6 +8,7 @@
 #import "SwrveTalkQA.h"
 #import "SwrveConversationsNavigationController.h"
 #import "SwrveConversationItemViewController.h"
+#import "SwrveConversationContainerViewController.h"
 #import "SwrvePermissions.h"
 
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
@@ -1092,13 +1093,10 @@ static NSNumber* numberFromJsonWithDefault(NSDictionary* json, NSString* key, in
             scivc.navigationItem.leftBarButtonItem = cancelButton;
 
             dispatch_async(dispatch_get_main_queue(), ^{
+                SwrveConversationContainerViewController* rootController = [[SwrveConversationContainerViewController alloc] initWithChildViewController:svnc];
                 self.conversationWindow.rootViewController = [[UIViewController alloc] init];
-//                self.conversationWindow.windowLevel = UIWindowLevelAlert + 1;
                 [self.conversationWindow makeKeyAndVisible];
-                
-                UIViewController* rootController = self.conversationWindow.rootViewController;
                 [rootController.view endEditing:YES];
-                [rootController presentViewController:svnc animated:YES completion:nil];
             });
         }
     }

--- a/SwrveDemo/SwrveDemoFramework.xcodeproj/project.pbxproj
+++ b/SwrveDemo/SwrveDemoFramework.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		1B9A35D71A8CCF8500F34406 /* SwrveConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B9A35D61A8CCF8500F34406 /* SwrveConversation.m */; };
 		1B9A35DA1A8CCFCA00F34406 /* SwrveBaseCampaign.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B9A35D91A8CCFCA00F34406 /* SwrveBaseCampaign.m */; };
 		1B9A35DD1A8CD0A500F34406 /* SwrveConversationCampaign.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B9A35DC1A8CD0A500F34406 /* SwrveConversationCampaign.m */; };
+		1B9B66F51BC66F0E0011425C /* SwrveConversationContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B9B66F41BC66F0E0011425C /* SwrveConversationContainerViewController.m */; };
 		30A4F72116B05C2500642E8E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30A4F72016B05C2500642E8E /* UIKit.framework */; };
 		30A4F72316B05C2500642E8E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30A4F72216B05C2500642E8E /* Foundation.framework */; };
 		30A4F72516B05C2500642E8E /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30A4F72416B05C2500642E8E /* CoreGraphics.framework */; };
@@ -335,6 +336,8 @@
 		1B9A35DB1A8CD0A500F34406 /* SwrveConversationCampaign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwrveConversationCampaign.h; sourceTree = "<group>"; };
 		1B9A35DC1A8CD0A500F34406 /* SwrveConversationCampaign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SwrveConversationCampaign.m; sourceTree = "<group>"; };
 		1B9A35DE1A8CE56100F34406 /* SwrvePrivateBaseCampaign.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwrvePrivateBaseCampaign.h; sourceTree = "<group>"; };
+		1B9B66F31BC66F0E0011425C /* SwrveConversationContainerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwrveConversationContainerViewController.h; sourceTree = "<group>"; };
+		1B9B66F41BC66F0E0011425C /* SwrveConversationContainerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SwrveConversationContainerViewController.m; sourceTree = "<group>"; };
 		30A4F71C16B05C2500642E8E /* SwrveDemoFramework.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwrveDemoFramework.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		30A4F72016B05C2500642E8E /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		30A4F72216B05C2500642E8E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -813,6 +816,8 @@
 				1B9A35DC1A8CD0A500F34406 /* SwrveConversationCampaign.m */,
 				1B68148F1B0F3C1100FCDE4F /* SwrveConversationStyler.h */,
 				1B6814901B0F3C1100FCDE4F /* SwrveConversationStyler.m */,
+				1B9B66F31BC66F0E0011425C /* SwrveConversationContainerViewController.h */,
+				1B9B66F41BC66F0E0011425C /* SwrveConversationContainerViewController.m */,
 			);
 			name = Conversation;
 			path = ../Sdk/Conversation;
@@ -1107,6 +1112,7 @@
 				1B9A35D71A8CCF8500F34406 /* SwrveConversation.m in Sources */,
 				1B22100419B8AFFC00F378E6 /* SwrveImage.m in Sources */,
 				3AC4DBB91B2992D1004B57CB /* SwrveContentHTML.m in Sources */,
+				1B9B66F51BC66F0E0011425C /* SwrveConversationContainerViewController.m in Sources */,
 				093B596E16E027220028A4E1 /* TalkApiDemo.m in Sources */,
 				098C798116E93EF60080B266 /* TutorialDemo.m in Sources */,
 				1B592D191B28488B00908895 /* ISHPermissionRequestPhotoCamera.m in Sources */,


### PR DESCRIPTION
Use a container view controller that will display the child view controller after its animation has displayed on the UIWindow. Prevents displaying two new controllers at the same time and getting the 'unbalanced calls' warning.
https://swrvedev.jira.com/browse/SWRVE-9978
