### PR TITLE
Allow async processing of push notifications

### DIFF
--- a/Sdk/Talk/SwrveMessageController.h
+++ b/Sdk/Talk/SwrveMessageController.h
@@ -193,11 +193,18 @@ typedef void (^SwrveCustomButtonPressedCallback) (NSString* action);
  */
 - (void)setDeviceToken:(NSData*)deviceToken;
 
-/*! Process the given push notification.
+/*! Process the given push notification. Internally, it calls -pushNotificationReceived:atApplicationState: with current the application state.
  *
  * \param userInfo Push notification information.
  */
 - (void)pushNotificationReceived:(NSDictionary*)userInfo;
+
+/*! Process the given push notification.
+ *
+ * \param userInfo Push notification information.
+ * \param applicationState Application state at the time when the push notificatin was received.
+ */
+- (void)pushNotificationReceived:(NSDictionary*)userInfo atApplicationState:(UIApplicationState)applicationState;
 
 /*! Check if the user is a QA user. For internal use.
  *

--- a/Sdk/Talk/SwrveMessageController.h
+++ b/Sdk/Talk/SwrveMessageController.h
@@ -193,7 +193,7 @@ typedef void (^SwrveCustomButtonPressedCallback) (NSString* action);
  */
 - (void)setDeviceToken:(NSData*)deviceToken;
 
-/*! Process the given push notification. Internally, it calls -pushNotificationReceived:atApplicationState: with current the application state.
+/*! Process the given push notification. Internally, it calls -pushNotificationReceived:atApplicationState: with the current application state.
  *
  * \param userInfo Push notification information.
  */

--- a/Sdk/Talk/SwrveMessageController.m
+++ b/Sdk/Talk/SwrveMessageController.m
@@ -1321,9 +1321,15 @@ static NSNumber* numberFromJsonWithDefault(NSDictionary* json, NSString* key, in
 
 - (void) pushNotificationReceived:(NSDictionary*)userInfo
 {
+    [self pushNotificationReceived:userInfo atApplicationState:[UIApplication sharedApplication].applicationState];
+}
+
+- (void) pushNotificationReceived:(NSDictionary*)userInfo atApplicationState:(UIApplicationState)applicationState
+{
     if (self.pushEnabled) {
         // Do not process the push notification if the app was on the foreground
-        if ([self.analyticsSDK appInBackground]) {
+        BOOL appInBackground = applicationState != UIApplicationStateActive;
+        if (appInBackground) {
             [self.analyticsSDK pushNotificationReceived:userInfo];
             if (self.qaUser) {
                 [self.qaUser pushNotification:userInfo];

--- a/Sdk/Track/Swrve.h
+++ b/Sdk/Track/Swrve.h
@@ -693,10 +693,6 @@ typedef void (^SwrveResourcesUpdatedListener) ();
  */
 -(void) shutdown;
 
-/*! Used internally to detect if the app is in the background.
- */
--(BOOL) appInBackground;
-
 /*! Used internally to read location cache.
  */
 - (SwrveSignatureProtectedFile *)getLocationCampaignFile;

--- a/Sdk/Track/Swrve.m
+++ b/Sdk/Track/Swrve.m
@@ -1353,11 +1353,6 @@ static bool didSwizzle = false;
     [self setEventBuffer:nil];
 }
 
-- (BOOL) appInBackground {
-    UIApplicationState swrveState = [[UIApplication sharedApplication] applicationState];
-    return (swrveState == UIApplicationStateInactive || swrveState == UIApplicationStateBackground);
-}
-
 #pragma mark -
 #pragma mark Private methods
 


### PR DESCRIPTION
So far all push notifications had to be processed synchronously in `-application:didFinishLaunchingWithOptions:` app delegate's method.

This PR adds a telescope method, `-pushNotificationReceived:atApplicationState:`, to `SwrveMessageController` in order to overcome this limitation.
