### PR TITLE
using the NSString version of a variable instead of the NSNumber vers…

### DIFF
--- a/Sdk/Track/Swrve.m
+++ b/Sdk/Track/Swrve.m
@@ -1580,8 +1580,8 @@ static bool didSwizzle = false;
         }
         
         // Only process this push if we haven't seen it before
-        if (lastProcessedPushId == nil || ![pushIdentifier isEqualToString:lastProcessedPushId]) {
-            lastProcessedPushId = pushIdentifier;
+        if (lastProcessedPushId == nil || ![pushId isEqualToString:lastProcessedPushId]) {
+            lastProcessedPushId = pushId;
             
             // Process deeplink _d
             id pushDeeplinkRaw = [userInfo objectForKey:@"_d"];


### PR DESCRIPTION
using the NSString version of a variable instead of the NSNumber version to avoid a crash.
