### PR TITLE
10888 AVAudioSession is optional in SwrveContentVideo

### DIFF
--- a/Sdk/Conversation/SwrveContentVideo.h
+++ b/Sdk/Conversation/SwrveContentVideo.h
@@ -1,5 +1,7 @@
 #import "SwrveContentItem.h"
 
+//#define SWRVE_NO_PHOTO_CAMERA
+
 @interface SwrveContentVideo : SwrveContentItem <UIWebViewDelegate, UIGestureRecognizerDelegate>
 
 @property (readonly, atomic, strong) NSString *height;

--- a/Sdk/Conversation/SwrveContentVideo.h
+++ b/Sdk/Conversation/SwrveContentVideo.h
@@ -1,7 +1,5 @@
 #import "SwrveContentItem.h"
 
-//#define SWRVE_NO_PHOTO_CAMERA
-
 @interface SwrveContentVideo : SwrveContentItem <UIWebViewDelegate, UIGestureRecognizerDelegate>
 
 @property (readonly, atomic, strong) NSString *height;

--- a/Sdk/Conversation/SwrveContentVideo.m
+++ b/Sdk/Conversation/SwrveContentVideo.m
@@ -43,11 +43,9 @@
 -(void) loadViewWithContainerView:(UIView*)containerView {
     _containerView = containerView;
 
-#if !defined(SWRVE_NO_PHOTO_CAMERA)
     // Enable audio
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     [audioSession setCategory:AVAudioSessionCategoryPlayback error:nil];
-#endif //!defined(SWRVE_NO_PHOTO_CAMERA)
 
     // Create _view
     CGFloat vid_height = (_height) ? [_height floatValue] : 180.0;

--- a/Sdk/Conversation/SwrveContentVideo.m
+++ b/Sdk/Conversation/SwrveContentVideo.m
@@ -1,9 +1,6 @@
 #import "SwrveContentVideo.h"
 #import <MediaPlayer/MediaPlayer.h>
 #import <AVFoundation/AVFoundation.h>
-#import "SwrveSetup.h"
-#import "SwrveConversationEvents.h"
-
 #import "UIWebView+YouTubeVimeo.h"
 
 @interface SwrveContentVideo () {
@@ -45,11 +42,13 @@
 
 -(void) loadViewWithContainerView:(UIView*)containerView {
     _containerView = containerView;
-    
+
+#if !defined(SWRVE_NO_PHOTO_CAMERA)
     // Enable audio
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     [audioSession setCategory:AVAudioSessionCategoryPlayback error:nil];
-    
+#endif //!defined(SWRVE_NO_PHOTO_CAMERA)
+
     // Create _view
     CGFloat vid_height = (_height) ? [_height floatValue] : 180.0;
     _view = webview = [[UIWebView alloc] initWithFrame:CGRectMake(0, 0, 1, vid_height)];

--- a/Sdk/Permissions/ISHPermissionRequest+All.m
+++ b/Sdk/Permissions/ISHPermissionRequest+All.m
@@ -37,13 +37,11 @@
             break;
 
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
-#if !defined(SWRVE_NO_PHOTO_CAMERA)
 
         case ISHPermissionCategoryPhotoCamera:
             request = [ISHPermissionRequestPhotoCamera new];
             break;
 
-#endif //!defined(SWRVE_NO_PHOTO_CAMERA)
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
 
         case ISHPermissionCategoryAddressBook:

--- a/Sdk/Permissions/ISHPermissionRequest.h
+++ b/Sdk/Permissions/ISHPermissionRequest.h
@@ -10,11 +10,6 @@
 #import <Foundation/Foundation.h>
 #import "ISHPermissionCategory.h"
 
-//#define SWRVE_NO_ADDRESS_BOOK
-//#define SWRVE_NO_LOCATION
-//#define SWRVE_NO_PHOTO_CAMERA
-//#define SWRVE_NO_PHOTO_LIBRARY
-
 /**
  *  Enumeration for possible permission states.
  *  These are used inlieu of the permission state values 

--- a/Sdk/Permissions/ISHPermissionRequestPhotoCamera.h
+++ b/Sdk/Permissions/ISHPermissionRequestPhotoCamera.h
@@ -8,10 +8,6 @@
 
 #import "ISHPermissionRequest.h"
 
-#if !defined(SWRVE_NO_PHOTO_CAMERA)
-
 @interface ISHPermissionRequestPhotoCamera : ISHPermissionRequest
 
 @end
-
-#endif //!defined(SWRVE_NO_PHOTO_CAMERA)

--- a/Sdk/Permissions/ISHPermissionRequestPhotoCamera.m
+++ b/Sdk/Permissions/ISHPermissionRequestPhotoCamera.m
@@ -12,8 +12,6 @@
 #import "ISHPermissionRequestPhotoCamera.h"
 #import "ISHPermissionRequest+Private.h"
 
-#if !defined(SWRVE_NO_PHOTO_CAMERA)
-
 @implementation ISHPermissionRequestPhotoCamera
 
 - (ISHPermissionState)permissionState {
@@ -64,6 +62,3 @@
     }
 }
 @end
-
-#endif //!defined(SWRVE_NO_PHOTO_CAMERA)
-

--- a/Sdk/Talk/SwrvePermissions.h
+++ b/Sdk/Talk/SwrvePermissions.h
@@ -35,10 +35,8 @@ static NSString* swrve_permission_requestable           = @".requestable";
 + (void)requestPhotoLibrary:(Swrve*)sdk;
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
 
-#if !defined(SWRVE_NO_PHOTO_CAMERA)
 + (ISHPermissionState)checkCamera;
 + (void)requestCamera:(Swrve*)sdk;
-#endif //!defined(SWRVE_NO_PHOTO_CAMERA)
 
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
 + (ISHPermissionState)checkContacts;

--- a/Sdk/Talk/SwrvePermissions.m
+++ b/Sdk/Talk/SwrvePermissions.m
@@ -45,12 +45,10 @@ static NSString* asked_for_push_flag_key = @"swrve.asked_for_push_permission";
         return YES;
     }
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
-#if !defined(SWRVE_NO_PHOTO_CAMERA)
     else if([action caseInsensitiveCompare:@"swrve.request_permission.ios.camera"] == NSOrderedSame) {
         [SwrvePermissions requestCamera:sdk];
         return YES;
     }
-#endif //!defined(SWRVE_NO_PHOTO_CAMERA)
     
     return NO;
 }
@@ -64,9 +62,7 @@ static NSString* asked_for_push_flag_key = @"swrve.asked_for_push_permission";
 #if !defined(SWRVE_NO_PHOTO_LIBRARY)
     [permissionsStatus setValue:stringFromPermissionState([SwrvePermissions checkPhotoLibrary]) forKey:swrve_permission_photos];
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
-#if !defined(SWRVE_NO_PHOTO_CAMERA)
     [permissionsStatus setValue:stringFromPermissionState([SwrvePermissions checkCamera]) forKey:swrve_permission_camera];
-#endif //!defined(SWRVE_NO_PHOTO_CAMERA)
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
     [permissionsStatus setValue:stringFromPermissionState([SwrvePermissions checkContacts]) forKey:swrve_permission_contacts];
 #endif //!defined(SWRVE_NO_ADDRESS_BOOK)


### PR DESCRIPTION
SwrveContentVideo uses AVAudioSession which is an optional framework now when preprocessor macro SWRVE_NO_PHOTO_CAMERA is configured.

https://swrvedev.jira.com/browse/SWRVE-10888

@Sergio-Mira please
