### PR TITLE
Bug - refreshCampaignsAndResources - resourcesUpdatedCallback

### DIFF
--- a/SwrveSDK/SDK/Track/Swrve.m
+++ b/SwrveSDK/SDK/Track/Swrve.m
@@ -1174,7 +1174,7 @@ static bool didSwizzle = false;
             // Invoke listeners once to denote that the first attempt at downloading has finished
             // independent of whether the resources or campaigns have changed from cached values
             if ([[self config] resourcesUpdatedCallback]) {
-                [[self config] resourcesUpdatedCallback];
+                [[[self config] resourcesUpdatedCallback] invoke];
             }
         }
     }];


### PR DESCRIPTION
resourcesUpdatedCallback was not being invoked on first call to refreshCampaignsAndResources if remote call failed,
or there were no user_resouces to in the response to cache
