### PR TITLE
Move the CONVERSATION_VERSION out of SwrveSDK into SwrveConversationSDK.

### DIFF
--- a/SwrveConversationSDK/Conversation/SwrveBaseConversation.h
+++ b/SwrveConversationSDK/Conversation/SwrveBaseConversation.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import "SwrveMessageEventHandler.h"
 
+const static int CONVERSATION_VERSION = 3;
+
 @class SwrveConversationPane;
 
 @interface SwrveBaseConversation : NSObject

--- a/SwrveSDK/SDK/Talk/SwrveMessageController.h
+++ b/SwrveSDK/SDK/Talk/SwrveMessageController.h
@@ -10,8 +10,6 @@
 
 #endif
 
-const static int CONVERSATION_VERSION = 3;
-
 static NSString* const AUTOSHOW_AT_SESSION_START_TRIGGER = @"Swrve.Messages.showAtSessionStart";
 
 @class SwrveBaseCampaign;


### PR DESCRIPTION
Keeping up with how it's done on Android, and making it available for the Unity side is necessary.

@adam-govan and @dominicmarmionswrve please

Adam, we don't have a generic "SwrveConversationSDK.h" header to put things like this in.  Should one be created?  And should we maybe have that as a standard for all SDKs?
