### PR TITLE
13029 - Fix storyboard load location

### DIFF
--- a/SwrveConversationSDK/Conversation/SwrveBaseConversation.h
+++ b/SwrveConversationSDK/Conversation/SwrveBaseConversation.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "SwrveMessageEventHandler.h"
+#include <UIKit/UIKit.h>
 
 const static int CONVERSATION_VERSION = 3;
 
@@ -19,6 +20,12 @@ const static int CONVERSATION_VERSION = 3;
  * \returns Parsed conversation.
  */
 +(SwrveBaseConversation*)fromJSON:(NSDictionary*)json forController:(id<SwrveMessageEventHandler>)controller;
+
+/*! Load the storyboard resource.
+ *
+ * \returns UIStoryboard if loaded successfully.
+ */
++(UIStoryboard*)loadStoryboard;
 
 /*! Check if assets are downloaded.
  *

--- a/SwrveConversationSDK/Conversation/SwrveBaseConversation.m
+++ b/SwrveConversationSDK/Conversation/SwrveBaseConversation.m
@@ -30,6 +30,11 @@
     return [[[SwrveBaseConversation alloc] init] updateWithJSON:json forController:controller];
 }
 
++(UIStoryboard*) loadStoryboard
+{
+    return [UIStoryboard storyboardWithName:@"SwrveConversation" bundle:[NSBundle bundleForClass:[SwrveBaseConversation class]]];
+}
+
 -(BOOL)assetsReady:(NSSet*)assets {
     for (NSDictionary* page in self.pages) {
         SwrveConversationPane *pane = [[SwrveConversationPane alloc] initWithDictionary:page];

--- a/SwrveSDK/SDK/Talk/SwrveMessageController.m
+++ b/SwrveSDK/SDK/Talk/SwrveMessageController.m
@@ -1092,7 +1092,7 @@ static NSNumber* numberFromJsonWithDefault(NSDictionary* json, NSString* key, in
             // Create a view to show the conversation
             
             @try {
-                UIStoryboard* storyBoard = [UIStoryboard storyboardWithName:@"SwrveConversation" bundle:[NSBundle bundleForClass:self.class]];
+                UIStoryboard* storyBoard = [SwrveBaseConversation loadStoryboard];
                 SwrveConversationItemViewController* scivc = [storyBoard instantiateViewControllerWithIdentifier:@"SwrveConversationItemViewController"];
                 self.swrveConversationItemViewController = scivc;
             }

--- a/SwrveSDK/SDK/Track/Swrve.h
+++ b/SwrveSDK/SDK/Track/Swrve.h
@@ -16,7 +16,7 @@
 #endif
 
 /*! The release version of this SDK. */
-#define SWRVE_SDK_VERSION "4.4"
+#define SWRVE_SDK_VERSION "4.4.1"
 
 /*! Swrve stack names. */
 enum SwrveStack {


### PR DESCRIPTION
When frameworks are used, using "self.class" from SwrveSDK looks for resources in the SwrveSDK bundle.
