### PR TITLE
13293 [ios] ios7 orientation iam issue

### DIFF
--- a/SwrveSDK/SDK/Talk/SwrveMessageViewController.m
+++ b/SwrveSDK/SDK/Talk/SwrveMessageViewController.m
@@ -32,6 +32,9 @@
     CGRect screenRect = [[[UIApplication sharedApplication] keyWindow] bounds];
     self.viewportWidth = screenRect.size.width;
     self.viewportHeight = screenRect.size.height;
+    if(SYSTEM_VERSION_LESS_THAN(@"8.0")){
+        [[NSNotificationCenter defaultCenter] addObserver:self  selector:@selector(orientationChanged:)    name:UIDeviceOrientationDidChangeNotification  object:nil];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -199,10 +202,20 @@
 }
 // ---------------
 
+- (void)orientationChanged:(NSNotification *)notification{
+    //After a given delay to allow for the correct orientation and view.frame to be calculated. Redraw the Message
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (u_int64_t)0.01 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [self viewDidAppear:NO];
+    });
+}
+
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
     [self.navigationController setNavigationBarHidden:NO animated:animated];
+    if(SYSTEM_VERSION_LESS_THAN(@"8.0")){
+        [[NSNotificationCenter defaultCenter]removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+    }
 }
 
 @end


### PR DESCRIPTION
Had to add an Orientation Notification which forces a redraw of the MessageViewController. 

after a small delay to allow for the frame and correct orientation to show, it grabs the correct IAM and renders it in the right place. 

Dev Tested on an iOS7 iPod Touch, iOS 8.4 iPhone 6 and an iOS9.3 iPad Air 2

@seaders / @Sergio-Mira / @dominicmarmionswrve can you guys take a quick look? 🍻 
