### PR TITLE
[ios] Remove Swrve Config Debug Log when Running Unit Tests

### DIFF
--- a/SwrveSDK/SDK/Track/Swrve.m
+++ b/SwrveSDK/SDK/Track/Swrve.m
@@ -1910,7 +1910,10 @@ static NSString* httpScheme(bool useHttps)
     for (NSString* key in deviceProperties) {
         [formattedDeviceData appendFormat:@"  %24s: %@\n", [key UTF8String], [deviceProperties objectForKey:key]];
     }
-    DebugLog(@"Swrve config:\n%@", formattedDeviceData);
+    
+    if (!getenv("RUNNING_UNIT_TESTS")) {
+        DebugLog(@"Swrve config:\n%@", formattedDeviceData);
+    }
     [self updateDeviceInfo];
     [self userUpdate:self.deviceInfo];
 }


### PR DESCRIPTION
There is already a Boolean build flag in our Unit tests in the UnitTest/CocoaPodsUnitTests Scheme named:  **RUNNING_UNIT_TESTS**

This makes use of that flag and if it's True, don't display the Swrve Config info in the Debug Log. 
This makes debugging out build easier. 

@dominicmarmionswrve / @seaders  
