### PR TITLE
Fix a crash

### DIFF
--- a/SwrveSDK/SDK/Talk/SwrveTriggerCondition.m
+++ b/SwrveSDK/SDK/Talk/SwrveTriggerCondition.m
@@ -48,6 +48,13 @@
         if([payload objectForKey:_key] != [NSNull null]) {
             
             NSString *payloadValue = [payload objectForKey:_key];
+            if (![payloadValue isKindOfClass:NSString.class]) {
+                if ([payloadValue respondsToSelector:@selector(stringValue)]) {
+                    payloadValue = [(id)payloadValue stringValue];
+                }else{
+                    return NO;
+                }
+            }
             return (payloadValue && [payloadValue isEqualToString:_value]);
         }else{
             return NO;


### PR DESCRIPTION
When sending an In-App message depending on event attributes which value is a number, the App crashes. This pull request fixes this problem.
