### PR TITLE
add SWRVE_NO_CAMERA preprocess macro

### DIFF
--- a/SwrveSDKCommon/Common/Permissions/ISHPermissionRequest+All.m
+++ b/SwrveSDKCommon/Common/Permissions/ISHPermissionRequest+All.m
@@ -37,11 +37,11 @@
             break;
 
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
-
+#if !defined(SWRVE_NO_CAMERA)
         case ISHPermissionCategoryPhotoCamera:
             request = [ISHPermissionRequestPhotoCamera new];
             break;
-
+#endif //!defined(SWRVE_NO_CAMERA)
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
 
         case ISHPermissionCategoryAddressBook:

--- a/SwrveSDKCommon/Common/Permissions/ISHPermissionRequestPhotoCamera.h
+++ b/SwrveSDKCommon/Common/Permissions/ISHPermissionRequestPhotoCamera.h
@@ -8,6 +8,11 @@
 
 #import "ISHPermissionRequest.h"
 
+#if !defined(SWRVE_NO_CAMERA)
+
 @interface ISHPermissionRequestPhotoCamera : ISHPermissionRequest
 
 @end
+
+#endif //!defined(SWRVE_NO_CAMERA)
+

--- a/SwrveSDKCommon/Common/Permissions/ISHPermissionRequestPhotoCamera.m
+++ b/SwrveSDKCommon/Common/Permissions/ISHPermissionRequestPhotoCamera.m
@@ -12,6 +12,8 @@
 #import "ISHPermissionRequestPhotoCamera.h"
 #import "ISHPermissionRequest+Private.h"
 
+#if !defined(SWRVE_NO_CAMERA)
+
 @implementation ISHPermissionRequestPhotoCamera
 
 - (ISHPermissionState)permissionState {
@@ -68,3 +70,5 @@
     }
 }
 @end
+
+#endif //!defined(SWRVE_NO_CAMERA)

--- a/SwrveSDKCommon/Common/SwrvePermissions.h
+++ b/SwrveSDKCommon/Common/SwrvePermissions.h
@@ -35,8 +35,10 @@ static NSString* swrve_permission_requestable           = @".requestable";
 + (void)requestPhotoLibrary:(id<SwrveCommonDelegate>)sdk;
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
 
+#if !defined(SWRVE_NO_CAMERA)
 + (ISHPermissionState)checkCamera;
 + (void)requestCamera:(id<SwrveCommonDelegate>)sdk;
+#endif //!defined(SWRVE_NO_CAMERA)
 
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
 + (ISHPermissionState)checkContacts;

--- a/SwrveSDKCommon/Common/SwrvePermissions.m
+++ b/SwrveSDKCommon/Common/SwrvePermissions.m
@@ -9,7 +9,9 @@ static ISHPermissionRequest *_locationWhenInUseRequest = nil;
 #if !defined(SWRVE_NO_PHOTO_LIBRARY)
 static ISHPermissionRequest *_photoLibraryRequest = nil;
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
+#if !defined(SWRVE_NO_CAMERA)
 static ISHPermissionRequest *_cameraRequest = nil;
+#endif //!defined(SWRVE_NO_CAMERA)
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
 static ISHPermissionRequest *_contactsRequest = nil;
 #endif //!defined(SWRVE_NO_ADDRESS_BOOK)
@@ -52,10 +54,12 @@ static NSString* asked_for_push_flag_key = @"swrve.asked_for_push_permission";
         return YES;
     }
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
+#if !defined(SWRVE_NO_CAMERA)
     if([action caseInsensitiveCompare:@"swrve.request_permission.ios.camera"] == NSOrderedSame) {
         [SwrvePermissions requestCamera:sdk];
         return YES;
     }
+#endif //!defined(SWRVE_NO_CAMERA)
     return NO;
 }
 
@@ -68,7 +72,9 @@ static NSString* asked_for_push_flag_key = @"swrve.asked_for_push_permission";
 #if !defined(SWRVE_NO_PHOTO_LIBRARY)
     [permissionsStatus setValue:stringFromPermissionState([SwrvePermissions checkPhotoLibrary]) forKey:swrve_permission_photos];
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
+#if !defined(SWRVE_NO_CAMERA)
     [permissionsStatus setValue:stringFromPermissionState([SwrvePermissions checkCamera]) forKey:swrve_permission_camera];
+#endif //!defined(SWRVE_NO_CAMERA)
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
     [permissionsStatus setValue:stringFromPermissionState([SwrvePermissions checkContacts]) forKey:swrve_permission_contacts];
 #endif //!defined(SWRVE_NO_ADDRESS_BOOK)
@@ -200,6 +206,7 @@ static NSString* asked_for_push_flag_key = @"swrve.asked_for_push_permission";
 }
 #endif //!defined(SWRVE_NO_PHOTO_LIBRARY)
 
+#if !defined(SWRVE_NO_CAMERA)
 +(ISHPermissionRequest*)cameraRequest {
     if (!_cameraRequest) {
         _cameraRequest = [ISHPermissionRequest requestForCategory:ISHPermissionCategoryPhotoCamera];
@@ -220,6 +227,7 @@ static NSString* asked_for_push_flag_key = @"swrve.asked_for_push_permission";
         [sdk userUpdate:[SwrvePermissions currentStatusWithSDK:sdk]];
     }];
 }
+#endif //!defined(SWRVE_NO_CAMERA)
 
 #if !defined(SWRVE_NO_ADDRESS_BOOK)
 +(ISHPermissionRequest*)contactsRequest {


### PR DESCRIPTION
This option will allow us to remove the following error when we upload to iTunesConnect:

"This app attempts to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSCameraUsageDescription key with a string value explaining to the user how the app uses this data."
