### PR TITLE
Verbose Logging option for all DebugLog() entries.

### DIFF
--- a/SwrveSDKCommon/Common/SwrveCommon.h
+++ b/SwrveSDKCommon/Common/SwrveCommon.h
@@ -33,7 +33,11 @@
 #pragma clang diagnostic ignored "-Wgnu"
 
 #ifndef SWRVE_DISABLE_LOGS
+#if SWRVE_VERBOSE_LOGS
+#define DebugLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);
+#else
 #define DebugLog( s, ... ) NSLog(s, ##__VA_ARGS__)
+#endif
 #else
 #define DebugLog( s, ... )
 #endif


### PR DESCRIPTION
added a verbose logging option which can be turned on with SWRVE_VERBOSE_LOGS in GCC pre processor flags

essentially by adding `SWRVE_VERBOSE_LOGS` as one of your `GCC_PREPROCESSOR_DEFINITIONS` you change the logs from this: 

`2016-11-15 16:21:50.604 TestApp[25258:3247428] Not showing message: no candidate messages for qa.trigger.always-on`

To this:
`2016-11-15 16:20:22.075 TestApp[25067:3194544] -[SwrveMessageController getConversationForEvent:withPayload:] [Line 918] Not showing message: no candidate messages for qa.trigger.always-on`