### PR TITLE
using the success boolean returned from registering a font

### DIFF
--- a/SwrveConversationSDK/Conversation/SwrveConversationStyler.m
+++ b/SwrveConversationSDK/Conversation/SwrveConversationStyler.m
@@ -179,13 +179,13 @@
                 }
                 if (uiFont == NULL) {
                     CGDataProviderRelease(fontDataProvider);
-                    CFErrorRef error;
-                    CTFontManagerRegisterGraphicsFont(cgFont, &error);
-                    if (error) {
-                        DebugLog(@"Error registering font: %@.\nError: %@", fontName, error);
-                    } else {
-                        CGFontRelease(cgFont);
+                    CFErrorRef cfError;
+                    BOOL success = CTFontManagerRegisterGraphicsFont(cgFont, &cfError);
+                    CGFontRelease(cgFont);
+                    if (success) {
                         uiFont = [UIFont fontWithName:newFontName size:[fontSize floatValue]];
+                    } else {
+                        DebugLog(@"Error registering font: %@ fontPath:%@", fontName, fontPath);
                     }
                 }
             } else {


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-14098

@Sergio-Mira @adam-govan Important change to how invalid/bad fonts are registered. Check the boolean returned from:
https://developer.apple.com/reference/coretext/1499499-ctfontmanagerregistergraphicsfon?language=objc

There's a test for this in private.