### PR TITLE
Fix build check for iOS SDK version

### DIFF
--- a/SwrveSDK/SDK/Talk/SwrveMessageController.h
+++ b/SwrveSDK/SDK/Talk/SwrveMessageController.h
@@ -112,7 +112,7 @@ typedef void (^SwrveCustomButtonPressedCallback) (NSString* action);
 @end
 
 /*! In-app messages controller */
-#if defined(__IPHONE_10_0)
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
 @interface SwrveMessageController : NSObject<SwrveMessageDelegate, SwrveMessageEventHandler, CAAnimationDelegate>
 #else
 @interface SwrveMessageController : NSObject<SwrveMessageDelegate, SwrveMessageEventHandler>


### PR DESCRIPTION
Previous would not compile on Xcode 7.3.1 with base SDK 9.3, since __IPHONE_10_0 is already defined there.
This is the method recommended by Apple.