### PR TITLE
Fixed cache folder issue and font color issue in multiinputvalue atom

### DIFF
--- a/SwrveConversationSDK/Conversation/SwrveContentImage.m
+++ b/SwrveConversationSDK/Conversation/SwrveContentImage.m
@@ -1,4 +1,5 @@
 #import "SwrveContentImage.h"
+#import "SwrveCommon.h"
 
 @interface SwrveContentImage () {
     UIImageView *iv;
@@ -16,9 +17,8 @@
 -(void) loadViewWithContainerView:(UIView*)containerView {
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0ul);
     dispatch_async(queue, ^{
-        NSString* cache = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-        NSString* swrve_folder = @"com.ngt.msgs";
-        NSURL* bgurl = [NSURL fileURLWithPathComponents:[NSArray arrayWithObjects:cache, swrve_folder, self.value, nil]];
+        NSString *cacheFolder = [SwrveCommon swrveCacheFolder];
+        NSURL* bgurl = [NSURL fileURLWithPathComponents:[NSArray arrayWithObjects:cacheFolder, self.value, nil]];
         self->image = [[UIImage alloc] initWithData:[NSData dataWithContentsOfURL:bgurl]];
         [self sizeAndDisplayInContainer:containerView];
     });

--- a/SwrveConversationSDK/Conversation/SwrveConversationStyler.m
+++ b/SwrveConversationSDK/Conversation/SwrveConversationStyler.m
@@ -2,7 +2,6 @@
 #import "SwrveConversationButton.h"
 #import "SwrveCommon.h"
 #import <CoreText/CoreText.h>
-#import <CoreText/CTFontManager.h>
 
 #define kSwrveKeyBg @"bg"
 #define kSwrveKeyFg @"fg"
@@ -167,8 +166,8 @@
     } else {
         uiFont = [UIFont fontWithName:fontName size:[fontSize floatValue]];
         if (!uiFont) {
-            NSString *cache = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-            NSString *fontPath = [cache stringByAppendingPathComponent:fontName];
+            NSString *cacheFolder = [SwrveCommon swrveCacheFolder];
+            NSString *fontPath = [cacheFolder stringByAppendingPathComponent:fontName];
             BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:fontPath];
             if (fileExists) {
                 NSURL *url = [NSURL fileURLWithPath:fontPath];

--- a/SwrveConversationSDK/Conversation/SwrveInputMultiValue.m
+++ b/SwrveConversationSDK/Conversation/SwrveInputMultiValue.m
@@ -115,7 +115,6 @@
     if (cell == nil) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"descriptionCell"];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
-        cell.userInteractionEnabled = NO;
     }
 
     UIFont *fallbackFont = [UIFont boldSystemFontOfSize:[kSwrveDefaultMultiValueDescriptionFontSize floatValue]];
@@ -154,13 +153,7 @@
     [cell.textLabel setFont:cellFont];
     [cell.textLabel setText:[dict objectForKey:kSwrveKeyAnswerText]];
     [cell.textLabel setNumberOfLines:0];
-
-    if (cellStyle) {
-        [SwrveConversationStyler styleView:cell withStyle:cellStyle];
-    } else {
-        [SwrveConversationStyler styleView:cell withStyle:self.style];
-    }
-
+    [SwrveConversationStyler styleView:cell withStyle:cellStyle];
     return cell;
 }
 

--- a/SwrveSDK/SDK/Talk/SwrveButton.m
+++ b/SwrveSDK/SDK/Talk/SwrveButton.m
@@ -1,4 +1,5 @@
 #import "SwrveButton.h"
+#import "SwrveCommon.h"
 
 @interface SwrveButton()
 
@@ -41,10 +42,8 @@ static CGPoint scaled(CGPoint point, float scale)
                              andCenterX:(float)cx
                              andCenterY:(float)cy
 {
-    NSString* cache = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-    NSString* swrve_folder = @"com.ngt.msgs";
-    
-    NSURL* url_up = [NSURL fileURLWithPathComponents:[NSArray arrayWithObjects:cache, swrve_folder, image, nil]];
+    NSString *cacheFolder = [SwrveCommon swrveCacheFolder];
+    NSURL* url_up = [NSURL fileURLWithPathComponents:[NSArray arrayWithObjects:cacheFolder, image, nil]];
     UIImage* up   = [UIImage imageWithData:[NSData dataWithContentsOfURL:url_up]];
 
     UIButton* result;

--- a/SwrveSDK/SDK/Talk/SwrveMessageController.m
+++ b/SwrveSDK/SDK/Talk/SwrveMessageController.m
@@ -12,7 +12,6 @@
 
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
-static NSString* swrve_folder         = @"com.ngt.msgs";
 static NSString* swrve_campaign_cache = @"cmcc2.json";
 static NSString* swrve_campaign_cache_signature = @"cmccsgt2.txt";
 static NSString* swrve_device_token_key = @"swrve_device_token";
@@ -154,8 +153,7 @@ const static int DEFAULT_MIN_DELAY           = 55;
 {
     self = [super init];
 
-    NSString *cacheRoot = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-    NSString *cacheFolder = [cacheRoot stringByAppendingPathComponent:swrve_folder];
+    NSString *cacheFolder = [SwrveCommon swrveCacheFolder];
     self.assetsManager      = [[SwrveAssetsManager alloc] initWithRestClient:sdk.restClient andCacheFolder:cacheFolder];
 
     CGRect screen_bounds = [sdk getDeviceScreenBounds];

--- a/SwrveSDK/SDK/Talk/SwrveMessageFormat.m
+++ b/SwrveSDK/SDK/Talk/SwrveMessageFormat.m
@@ -194,9 +194,7 @@ static CGFloat extractHex(NSString* color, NSUInteger index) {
     DebugLog(@"MessageViewFormat scale :%g", self.scale);
     DebugLog(@"UI scale :%g", screenScale);
     
-    NSString* cache = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-    NSString* swrve_folder = @"com.ngt.msgs";
-    [self addImageViews:containerView cachePath:cache swrveFolderPath:swrve_folder centerX:logical_half_screen_width centerY:logical_half_screen_height scale:renderScale];
+    [self addImageViews:containerView centerX:logical_half_screen_width centerY:logical_half_screen_height scale:renderScale];
     [self addButtonViews:containerView delegate:delegate centerX:logical_half_screen_width centerY:logical_half_screen_height scale:renderScale];
     
     if (rotated) {
@@ -229,10 +227,8 @@ static CGFloat extractHex(NSString* color, NSUInteger index) {
     
     DebugLog(@"MessageViewFormat scale :%g", self.scale);
     DebugLog(@"UI scale :%g", screenScale);
-    
-    NSString* cache = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-    NSString* swrve_folder = @"com.ngt.msgs";
-    [self addImageViews:containerView cachePath:cache swrveFolderPath:swrve_folder centerX:centerX centerY:centerY scale:renderScale];
+
+    [self addImageViews:containerView centerX:centerX centerY:centerY scale:renderScale];
     [self addButtonViews:containerView delegate:delegate centerX:centerX centerY:centerY scale:renderScale];
     
     [containerView setCenter:CGPointMake(centerX, centerY)];
@@ -271,11 +267,12 @@ static CGFloat extractHex(NSString* color, NSUInteger index) {
     }
 }
 
--(void)addImageViews:(UIView*)containerView cachePath:(NSString*)cachePath swrveFolderPath:(NSString*)swrveFolderPath centerX:(CGFloat)centerX centerY:(CGFloat)centerY scale:(CGFloat)renderScale
+-(void)addImageViews:(UIView*)containerView centerX:(CGFloat)centerX centerY:(CGFloat)centerY scale:(CGFloat)renderScale
 {
+    NSString *cacheFolder = [SwrveCommon swrveCacheFolder];
     for (SwrveImage* backgroundImage in self.images)
     {
-        NSURL* bgurl = [NSURL fileURLWithPathComponents:[NSArray arrayWithObjects:cachePath, swrveFolderPath, backgroundImage.file, nil]];
+        NSURL* bgurl = [NSURL fileURLWithPathComponents:[NSArray arrayWithObjects:cacheFolder, backgroundImage.file, nil]];
         UIImage* background = [UIImage imageWithData:[NSData dataWithContentsOfURL:bgurl]];
         
         CGRect frame = CGRectMake(0, 0,

--- a/SwrveSDKCommon/Common/SwrveCommon.h
+++ b/SwrveSDKCommon/Common/SwrveCommon.h
@@ -26,6 +26,7 @@
 
 +(id<SwrveCommonDelegate>) sharedInstance;
 +(void) addSharedInstance:(id<SwrveCommonDelegate>)swrveCommon;
++ (NSString *)swrveCacheFolder;
 
 @end
 

--- a/SwrveSDKCommon/Common/SwrveCommon.m
+++ b/SwrveSDKCommon/Common/SwrveCommon.m
@@ -1,17 +1,22 @@
 #import "SwrveCommon.h"
 
-static id<SwrveCommonDelegate> _sharedInstance = NULL;
+static id <SwrveCommonDelegate> _sharedInstance = NULL;
 
 @implementation SwrveCommon
 
-+(void) addSharedInstance:(id<SwrveCommonDelegate>)sharedInstance
-{
++ (void)addSharedInstance:(id <SwrveCommonDelegate>)sharedInstance {
     _sharedInstance = sharedInstance;
 }
 
-+(id<SwrveCommonDelegate>) sharedInstance
-{
++ (id <SwrveCommonDelegate>)sharedInstance {
     return _sharedInstance;
+}
+
++ (NSString *)swrveCacheFolder {
+    NSString *cacheRoot = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
+    NSString *swrve_folder = @"com.ngt.msgs";
+    NSString *cacheFolder = [cacheRoot stringByAppendingPathComponent:swrve_folder];
+    return cacheFolder;
 }
 
 @end


### PR DESCRIPTION
@Sergio-Mira @adam-govan please

- Using a common piece of code for getting swrve cache folder, and also fixed a bug here in conversation styling
- Fixed text color issue with header of the MultiInputValue atom. When disabled, it was always grey. Making this enabled does not change behaviour, but allows the text color to be configured correctly.