### PR TITLE
Not converting native text size units to points

### DIFF
--- a/SwrveConversationSDK/Conversation/SwrveConversationStyler.m
+++ b/SwrveConversationSDK/Conversation/SwrveConversationStyler.m
@@ -1,7 +1,6 @@
 #import "SwrveConversationStyler.h"
 #import "SwrveConversationButton.h"
 #import "SwrveCommon.h"
-#import "SwrveUtils.h"
 #import <CoreText/CoreText.h>
 
 #define kSwrveKeyBg @"bg"
@@ -160,7 +159,7 @@
 
     NSString *fontName = [style objectForKey:kSwrveKeyFontFile];
     CGFloat fontSizePixels = [[style objectForKey:kSwrveKeyTextSize] floatValue];
-    CGFloat fontSizePoints = [SwrveUtils convertPixelsToPoints:fontSizePixels];
+    CGFloat fontSizePoints = fontSizePixels;
 
     UIFont *uiFont;
     if (fontName && [fontName length] == 0) { // will be blank for system font and for v1/v2/v3 of conversations


### PR DESCRIPTION
Not converting native text size units to points.

It seems like html text size declared in pixels is equal to same text size value given to UIFonts (which according to UIFont api docs should be points).

This gives a more consistent text size across atoms.

@Sergio-Mira please