### PR TITLE
[ios] 14748 Hotfix for offline event Stream

### DIFF
--- a/SwrveConversationSDK.podspec
+++ b/SwrveConversationSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SwrveConversationSDK"
-  s.version          = "4.7.0"
+  s.version          = "4.7.1"
   s.summary          = "iOS Conversation SDK for Swrve."
   s.homepage         = "http://www.swrve.com"
   s.license          = { "type" => "Apache License, Version 2.0", "file" => s.name.to_s + "/LICENSE" }
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.public_header_files = s.name.to_s + '/Conversation/**/*.h'
   s.resources = s.name.to_s + '/Resources/**/*.*'
 
-  s.dependency 'SwrveSDKCommon', '4.7.0'
+  s.dependency 'SwrveSDKCommon', '4.7.1'
 
   s.compiler_flags = '-DSWRVE_CONVERSATION_SDK'
 end

--- a/SwrveSDK.podspec
+++ b/SwrveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SwrveSDK"
-  s.version          = "4.7.0"
+  s.version          = "4.7.1"
   s.summary          = "iOS SDK for Swrve."
   s.homepage         = "http://www.swrve.com"
   s.license          = { "type" => "Apache License, Version 2.0", "file" => s.name.to_s + "/LICENSE" }
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
   s.source_files = s.name.to_s + '/SDK/**/*.{m,h}'
   s.public_header_files = s.name.to_s + '/SDK/**/*.h'
 
-  s.dependency 'SwrveSDKCommon', '4.7.0'
-  s.dependency 'SwrveConversationSDK', '4.7.0'
+  s.dependency 'SwrveSDKCommon', '4.7.1'
+  s.dependency 'SwrveConversationSDK', '4.7.1'
 
   s.frameworks = 'UIKit', 'QuartzCore', 'CFNetwork', 'StoreKit', 'Security', 'CoreTelephony', 'MessageUI', 'CoreLocation', 'AVFoundation'
   # weak frameworks mark them as optional in xcode allowing for backwards compatibility with iOS7 and iOS8

--- a/SwrveSDK/SDK/Track/Swrve.h
+++ b/SwrveSDK/SDK/Track/Swrve.h
@@ -17,7 +17,7 @@
 #endif
 
 /*! The release version of this SDK. */
-#define SWRVE_SDK_VERSION "4.7"
+#define SWRVE_SDK_VERSION "4.7.1"
 
 /*! Swrve stack names. */
 enum SwrveStack {

--- a/SwrveSDK/SDK/Track/SwrveFileManagement.m
+++ b/SwrveSDK/SDK/Track/SwrveFileManagement.m
@@ -9,7 +9,10 @@
     NSString *appSupportDir = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject];
     if (![[NSFileManager defaultManager] fileExistsAtPath:appSupportDir isDirectory:NULL]) {
         NSError *error = nil;
-        if (![[NSFileManager defaultManager] createDirectoryAtPath:appSupportDir withIntermediateDirectories:YES attributes:nil error:&error]) {
+//        if (![[NSFileManager defaultManager] createDirectoryAtPath:appSupportDir withIntermediateDirectories:YES attributes:
+//              nil error:&error]) {
+        if (![[NSFileManager defaultManager] createDirectoryAtPath:appSupportDir withIntermediateDirectories:YES attributes:
+              [NSDictionary dictionaryWithObject:NSFileProtectionNone forKey:NSFileProtectionKey] error:&error]) {
             DebugLog(@"Error Creating an Application Support Directory %@", error.localizedDescription);
         } else {
             DebugLog(@"Successfully Created Directory: %@", appSupportDir);

--- a/SwrveSDK/SDK/Track/SwrveFileManagement.m
+++ b/SwrveSDK/SDK/Track/SwrveFileManagement.m
@@ -9,8 +9,6 @@
     NSString *appSupportDir = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject];
     if (![[NSFileManager defaultManager] fileExistsAtPath:appSupportDir isDirectory:NULL]) {
         NSError *error = nil;
-//        if (![[NSFileManager defaultManager] createDirectoryAtPath:appSupportDir withIntermediateDirectories:YES attributes:
-//              nil error:&error]) {
         if (![[NSFileManager defaultManager] createDirectoryAtPath:appSupportDir withIntermediateDirectories:YES attributes:
               [NSDictionary dictionaryWithObject:NSFileProtectionNone forKey:NSFileProtectionKey] error:&error]) {
             DebugLog(@"Error Creating an Application Support Directory %@", error.localizedDescription);

--- a/SwrveSDKCommon.podspec
+++ b/SwrveSDKCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SwrveSDKCommon"
-  s.version          = "4.7.0"
+  s.version          = "4.7.1"
   s.summary          = "iOS Common library for Swrve."
   s.homepage         = "http://www.swrve.com"
   s.license          = { "type" => "Apache License, Version 2.0", "file" => s.name.to_s + "/LICENSE" }

--- a/SwrveSDKCommon/Common/Permissions/ISHPermissionRequestLocation.m
+++ b/SwrveSDKCommon/Common/Permissions/ISHPermissionRequestLocation.m
@@ -151,7 +151,7 @@
     }
     
     [self handleCompletionBlock];
-
+    
     if ([self useFallback]) {
         [self.locationManager stopUpdatingLocation];
     }

--- a/samples/Objective-C/MessageCenterSample/Podfile
+++ b/samples/Objective-C/MessageCenterSample/Podfile
@@ -4,5 +4,5 @@ target 'MessageCenterSample' do
   pod 'SwrveSDK', :path => '../../..'
 
   # use remote podfile by commenting out above and uncommenting below
-  #pod 'SwrveSDK', '4.7'
+  #pod 'SwrveSDK', '4.7.1'
 end

--- a/samples/Swift/MessageCenterSample/Podfile
+++ b/samples/Swift/MessageCenterSample/Podfile
@@ -6,7 +6,7 @@ target 'MessageCenterSample' do
   pod 'SwrveSDK', :path => '../../..'
 
   # use remote podfile by commenting out above and uncommenting below
-  #pod 'SwrveSDK', '4.7'
+  #pod 'SwrveSDK', '4.7.1'
 end
 
 post_install do |installer|


### PR DESCRIPTION
Logic has been changed to Write to the events disk in the event of a network failure and to hold off declaring the events has sent until HTTP 2+ response. 

(this PR is for demonstrative purposes, the release will be against 4.7.1)