### PR TITLE
[ios] 14851 Location Campaign file i/o bug

### DIFF
--- a/SwrveSDK/SDK/Track/Swrve.m
+++ b/SwrveSDK/SDK/Track/Swrve.m
@@ -745,6 +745,7 @@ static bool didSwizzle = false;
         
         // legacy from 4.7 mirgrate the event file to suitable protection in background
         [SwrveMigrationsManager migrateFileProtectionAtPath:[[self eventFilename] path]];
+        [SwrveMigrationsManager migrateFileProtectionAtPath:swrveConfig.installTimeCacheFile];
 
         [self generateShortDeviceId];
 
@@ -2045,6 +2046,11 @@ static NSString* httpScheme(bool useHttps)
     NSURL *fileURL = [NSURL fileURLWithPath:self.config.locationCampaignCacheFile];
     NSURL *signatureURL = [NSURL fileURLWithPath:self.config.locationCampaignCacheSignatureFile];
     NSString *signatureKey = [self getSignatureKey];
+    
+    // legacy 4.7 migration
+    [SwrveMigrationsManager migrateFileProtectionAtPath:[fileURL path]];
+    [SwrveMigrationsManager migrateFileProtectionAtPath:[signatureURL path]];
+    
     SwrveSignatureProtectedFile *locationCampaignFile = [[SwrveSignatureProtectedFile alloc] initFile:fileURL signatureFilename:signatureURL usingKey:signatureKey];
     return locationCampaignFile;
 }


### PR DESCRIPTION
Fix for: https://swrvedev.jira.com/browse/SWRVE-14851

Campaign Locations Files and Install_date file need to be opened up to allow Lock Screen Read/Writes in the event of a Triggered Location Campaign. 

@Sergio-Mira can you take a look please? 🍻 